### PR TITLE
fix: update url and filter out deprecated versions

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -69,13 +69,15 @@ get_download_url() {
   is_linux && platform="linux" || platform="osx"
   if [ "$platform" = "osx" ]; then
     arch=""
+    platform="macos"
   elif [ "x86_64" = "$(uname -m)" ]; then
-    arch="64"
+    arch="_amd64"
   else
-    arch="32"
+    arch="_386"
   fi
 
-  echo "https://clis.cloud.ibm.com/download/bluemix-cli/${version}/${platform}${arch}/archive"
+  #echo "https://clis.cloud.ibm.com/download/bluemix-cli/${version}/${platform}${arch}/archive"
+  echo "https://download.clis.cloud.ibm.com/ibm-cloud-cli/${version}/binaries/IBM_Cloud_CLI_${version}_${platform}${arch}.tgz"
 }
 
 install "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -14,11 +14,11 @@ function sort_versions() {
 }
 
 function filter_versions() {
-  awk '/0.9.0/{y=1}y'
+  awk '/2.0.0/{y=1}y'
 }
 
 function join() {
   awk '$1=$1' ORS=' '
 }
 
-eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions | join
+eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions | filter_versions | join


### PR DESCRIPTION
Manually tested on ubuntu/macos until I have time to fix travis

```
root@4d2e5dacee51:~/asdf-ibmcloud# asdf list-all ibmcloud
2.0.0
2.0.1
2.0.2
2.0.3
2.1.0
2.1.1
root@4d2e5dacee51:~/asdf-ibmcloud# ic version
/root/.asdf/installs/ibmcloud/2.1.1/bin/ic version 2.1.1+19d7e02-2021-09-24T15:16:38+00:00
```